### PR TITLE
Synopsys Automated PR: Update commons-fileupload:commons-fileupload:1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2.2</version>
+            <version>1.5</version>
         </dependency>
 
         <!-- Apache Commons Upload -->


### PR DESCRIPTION
### Vulnerabilities associated with this PR: 
#### BDSA-2013-0013
Apache Commons FileUpload was discovered to be vulnerable to NULL byte poisoning due to the incorrect handling of filenames containing NULL bytes. The failure to check for NULL byte allows a remote unauthenticated attacker to upload or overwrite files on the system leading to unauthorized file modification, denial-of-service or remote code execution (RCE).
#### BDSA-2016-1573
Apache Commons FileUpload is vulnerable to remote code execution (RCE) due to unsafe deserialization of Java objects. This could allow an attacker to write, copy and delete arbitrary files on a target system within the privileges of the application.
#### BDSA-2013-0001
Apache Commons FileUpload program creates insecure temporary files in /tmp allowing an attacker to use a race condition symlink attack to overwrite files with predictable filenames.

This issue has been fixed in version **1.3** and higher.
#### BDSA-2016-1636
Apache Commons FileUpload is vulnerable to denial-of-service (DoS) attacks due to miscalculated buffer size.
#### BDSA-2023-0357
Apache Commons FileUpload does not sufficiently limit the the number of request parts that can be received via user input. An attacker can exploit this flaw by supplying a malicious upload or series of uploads and cause excessive resource allocation. This can trigger a denial-of-service (DoS).
#### BDSA-2014-0102
Apache Commons File-Upload contains a denial-of-service (DoS) flaw. This could allow a remote attacker to supply a specially crafted content-type, which upon being received by the component, triggers an infinite loop.