### PR TITLE
Synopsys Automated PR: Update org.apache.tomcat:tomcat-catalina:7.0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>7.0.27</version>
+            <version>10.1.7</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
### Vulnerabilities associated with this PR: 
#### BDSA-2017-1198
Apache Tomcat is vulnerable to Remote Code Execution (RCE) via JavaServer Pages (JSP) file upload.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
#### BDSA-2019-1146
An improper input validation vulnerability has been discovered in Apache Tomcat. An attacker could exploit this vulnerability through the command line to execute arbitrary code against the target system.

This vulnerability affects only Windows operating systems.
#### BDSA-2018-0511
Apache Tomcat contains a URL pattern processing error which can allow remote users to bypass certain security constraints on the vulnerable machine and potentially give them access to restricted web application resources.
#### CVE-2017-5664
The error page mechanism of the Java Servlet Specification requires that, when an error occurs and an error page is configured for the error that occurred, the original request and response are forwarded to the error page. This means that the request is presented to the error page with the original HTTP method. If the error page is a static file, expected behaviour is to serve content of the file as if processing a GET request, regardless of the actual HTTP method. The Default Servlet in Apache Tomcat 9.0.0.M1 to 9.0.0.M20, 8.5.0 to 8.5.14, 8.0.0.RC1 to 8.0.43 and 7.0.0 to 7.0.77 did not do this. Depending on the original request this could lead to unexpected and undesirable results for static error pages including, if the DefaultServlet is configured to permit writes, the replacement or removal of the custom error page. Notes for other user provided error pages: (1) Unless explicitly coded otherwise, JSPs ignore the HTTP method. JSPs used as error pages must must ensure that they handle any error dispatch as a GET request, regardless of the actual method. (2) By default, the response generated by a Servlet does depend on the HTTP method. Custom Servlets used as error pages must ensure that they handle any error dispatch as a GET request, regardless of the actual method.
#### BDSA-2013-0081
Apache Tomcat is vulnerable to remote code execution (RCE) due to the improper handling of unsafe object deserialization. This could allow an attacker to execute code, within the privileges of the application, by uploading and accessing a maliciously crafted JSP file.
#### BDSA-2016-0056
Apache Tomcat is vulnerable to the HTTPoxy class of vulnerabilities when running certain scripting languages under a CGI-like server.
#### CVE-2016-3092
The MultipartStream class in Apache Commons Fileupload before 1.3.2, as used in Apache Tomcat 7.x before 7.0.70, 8.x before 8.0.36, 8.5.x before 8.5.3, and 9.x before 9.0.0.M7 and other products, allows remote attackers to cause a denial of service (CPU consumption) via a long boundary string.
#### CVE-2015-5351
The (1) Manager and (2) Host Manager applications in Apache Tomcat 7.x before 7.0.68, 8.x before 8.0.31, and 9.x before 9.0.0.M2 establish sessions and send CSRF tokens for arbitrary new requests, which allows remote attackers to bypass a CSRF protection mechanism by using a token.
#### CVE-2020-8022
A Incorrect Default Permissions vulnerability in the packaging of tomcat on SUSE Enterprise Storage 5, SUSE Linux Enterprise Server 12-SP2-BCL, SUSE Linux Enterprise Server 12-SP2-LTSS, SUSE Linux Enterprise Server 12-SP3-BCL, SUSE Linux Enterprise Server 12-SP3-LTSS, SUSE Linux Enterprise Server 12-SP4, SUSE Linux Enterprise Server 12-SP5, SUSE Linux Enterprise Server 15-LTSS, SUSE Linux Enterprise Server for SAP 12-SP2, SUSE Linux Enterprise Server for SAP 12-SP3, SUSE Linux Enterprise Server for SAP 15, SUSE OpenStack Cloud 7, SUSE OpenStack Cloud 8, SUSE OpenStack Cloud Crowbar 8 allows local attackers to escalate from group tomcat to root. This issue affects: SUSE Enterprise Storage 5 tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server 12-SP2-BCL tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server 12-SP2-LTSS tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server 12-SP3-BCL tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server 12-SP3-LTSS tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server 12-SP4 tomcat versions prior to 9.0.35-3.39.1. SUSE Linux Enterprise Server 12-SP5 tomcat versions prior to 9.0.35-3.39.1. SUSE Linux Enterprise Server 15-LTSS tomcat versions prior to 9.0.35-3.57.3. SUSE Linux Enterprise Server for SAP 12-SP2 tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server for SAP 12-SP3 tomcat versions prior to 8.0.53-29.32.1. SUSE Linux Enterprise Server for SAP 15 tomcat versions prior to 9.0.35-3.57.3. SUSE OpenStack Cloud 7 tomcat versions prior to 8.0.53-29.32.1. SUSE OpenStack Cloud 8 tomcat versions prior to 8.0.53-29.32.1. SUSE OpenStack Cloud Crowbar 8 tomcat versions prior to 8.0.53-29.32.1.
#### BDSA-2019-1661
Apache Tomcat is vulnerable to reflected cross-site scripting (XSS) due to improper validation of user-supplied input in server-side includes (SSI) commands. This could allow an attacker to inject arbitrary web scripts and steal sensitive information such as authentication tokens or user cookies.
#### BDSA-2014-0185
Apache Tomcat is vulnerable to remote code execution (RCE) due to unsafe handling of serialized data. This could allow an attacker to execute malicious code on a target system, within the privileges of the application, by uploading a crafted JSP file. Vulnerable systems are limited to those using file upload functionality, an insecure `java.io.File` implementation and a custom JMX configuration.
#### BDSA-2020-1193
Apache Tomcat is vulnerable to remote code execution (RCE) due to the improper validation of a file storage location. A remote authenticated attacker could execute arbitrary code on a vulnerable server by sending crafted requests to that server.
#### CVE-2016-0714
The session-persistence implementation in Apache Tomcat 6.x before 6.0.45, 7.x before 7.0.68, 8.x before 8.0.31, and 9.x before 9.0.0.M2 mishandles session attributes, which allows remote authenticated users to bypass intended SecurityManager restrictions and execute arbitrary code in a privileged context via a web application that places a crafted object in a session.
#### BDSA-2020-0339
Apache Tomcat is vulnerable to information disclosure due to Apache JServ Protocol (AJP) connections being given higher privileges than that of an equivalent HTTP client connection. An attacker who is able to reach the Tomcat AJP connector could return arbitrary files from the target web application which may contain sensitive information.  

This vulnerability does not allow remote code execution by default.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
#### CVE-2015-5346
Session fixation vulnerability in Apache Tomcat 7.x before 7.0.66, 8.x before 8.0.30, and 9.x before 9.0.0.M2, when different session settings are used for deployments of multiple versions of the same web application, might allow remote attackers to hijack web sessions by leveraging use of a requestedSessionSSL field for an unintended request, related to CoyoteAdapter.java and Request.java.
#### BDSA-2021-0711
Apache Tomcat is vulnerable to remote code execution (RCE) due to the improper validation of a file storage location. A remote authenticated attacker could execute arbitrary code on a vulnerable server by sending crafted requests to that server.

**Note:** This vulnerability was originally assigned **CVE-2020-9484** (**BDSA-2020-1193**), however it was not completely fixed, and the vendor has stated it is still exploitable using a highly unlikely configuration edge case.
#### BDSA-2017-0114
Apache Tomcat contains a vulnerability whereby an attacker can create multiple requests to a target server and obtain responses for other requests.
#### BDSA-2016-0064
Apache Tomcat is vulnerable to a Java deserialization vulnerability, allowing remote code execution when `JmxRemoteLifecycleListener` is used and JMX ports are accessible to the attacker.
#### BDSA-2016-0258
The `ResourceLinkFactory` does not limit web application access to global resources to those resources explicitly linked to the web application. It is possible for a web application to access any global resource whether an explicit ResourceLink had been configured or not.
#### CVE-2014-0050
MultipartStream.java in Apache Commons FileUpload before 1.3.1, as used in Apache Tomcat, JBoss Web, and other products, allows remote attackers to cause a denial of service (infinite loop and CPU consumption) via a crafted Content-Type header that bypasses a loop's intended exit conditions.
#### BDSA-2019-4037
Apache Tomcat is vulnerable to session fixation due to improper handling of FORM authentication. This could allow an attacker to hijack the sessions of other users.
#### BDSA-2017-0111
Apache Tomcat contains a vulnerability which allows an untrusted web application to access and/or modify requests and responses relating to other web applications running under the same server.
#### BDSA-2016-0253
Apache Tomcat is vulnerable to a security bypass.  This allows malicious web applications that are deployed to Tomcat to escape the security context of Tomcat and potentially access other applications or data.
#### BDSA-2017-1783
Apache Tomcat is prone to a remote code-execution (*RCE*) vulnerability via the Javaserver Pages (*JSP*) Upload feature. If HTTP `PUT` Requests are accepted by the server, it is possible to upload  a specially crafted JSP file. If the JSP file contains arbitrary code it would then be executed after being requested. This vulnerability is related to a misconfiguration in the `web.xml` file.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
#### CVE-2014-0230
Apache Tomcat 6.x before 6.0.44, 7.x before 7.0.55, and 8.x before 8.0.9 does not properly handle cases where an HTTP response occurs before finishing the reading of an entire request body, which allows remote attackers to cause a denial of service (thread consumption) via a series of aborted upload attempts.
#### CVE-2013-0346
** DISPUTED ** Apache Tomcat 7.x uses world-readable permissions for the log directory and its files, which might allow local users to obtain sensitive information by reading a file. NOTE: One Tomcat distributor has stated "The tomcat log directory does not contain any sensitive information."
#### BDSA-2019-4038
Apache Tomcat is vulnerable to privilege escalation due to insufficient protections on manipulation of the RMI registry when Tomcat is configured with the JMX Remote Lifecycle Listener. This could allow a local attacker to obtain credentials to the JMX interface and compromise the Tomcat instance.
#### BDSA-2018-0455
Apache Tomcat is vulnerable to information disclosure. The component's security constraints only apply to Servlets after loading them. This can be manipulated by an attacker to escalate privileges and access resources that they are not authorized to read.
#### CVE-2016-0763
The setGlobalContext method in org/apache/naming/factory/ResourceLinkFactory.java in Apache Tomcat 7.x before 7.0.68, 8.x before 8.0.31, and 9.x before 9.0.0.M3 does not consider whether ResourceLinkFactory.setGlobalContext callers are authorized, which allows remote authenticated users to bypass intended SecurityManager restrictions and read or write to arbitrary application data, or cause a denial of service (application disruption), via a web application that sets a crafted global context.
#### BDSA-2015-0724
Due to a regression caused by a backported fix for CVE-2016-6816 Apache Tomcat is vulnerable to a denial-of-service (DoS) vulnerability.  This allows a remote attacker to cause Tomcat servers to become unresponsive by simply scanning multiple ports.
#### BDSA-2016-0066
A flaw in the error handling of an Apache Tomcat `Processor` can result in information leakage between HTTP requests.
#### BDSA-2020-1534
Apache Tomcat is vulnerable to denial-of-service (DoS) due to improper management of idle streams. An attacker could exploit this vulnerability by supplying a system with maliciously crafted HTTP/2 requests, in order to consume excessive CPU resources on a target server.
#### BDSA-2012-0080
Apache Tomcat is vulnerable to denial-of-service (DoS) via partial HTTP requests. An attacker could exploit this issue via a tool such as `Slowloris` in order to consume all the threads in the connection pool and cause a denial of service condition. 

**Note:** Per the vendor this is not something that the Tomcat Security Team views as a vulnerability because the relationship between the client side resources and server side resources is a linear one. This is a generic denial-of-service (DoS) problem and there is no magic solution. This issue has been discussed several times on the Tomcat mailing lists. This was first discussed on the public Tomcat users mailing list on 19 June 2009.
#### CVE-2013-4286
Apache Tomcat before 6.0.39, 7.x before 7.0.47, and 8.x before 8.0.0-RC3, when an HTTP connector or AJP connector is used, does not properly handle certain inconsistent HTTP request headers, which allows remote attackers to trigger incorrect identification of a request's length and conduct request-smuggling attacks via (1) multiple Content-Length headers or (2) a Content-Length header and a "Transfer-Encoding: chunked" header.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2005-2090.
#### BDSA-2018-3454
Apache Tomcat contains an open redirect vulnerability.  This allows an attacker to craft a URL that will redirect a victim to any arbitrary URI.
#### CVE-2014-0096
java/org/apache/catalina/servlets/DefaultServlet.java in the default servlet in Apache Tomcat before 6.0.40, 7.x before 7.0.53, and 8.x before 8.0.4 does not properly restrict XSLT stylesheets, which allows remote attackers to bypass security-manager restrictions and read arbitrary files via a crafted web application that provides an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue.
#### BDSA-2021-2071
Apache Tomcat is vulnerable to bypass of `LockDown` realm protections via incorrect parameter escaping.
#### CVE-2015-5345
The Mapper component in Apache Tomcat 6.x before 6.0.45, 7.x before 7.0.68, 8.x before 8.0.30, and 9.x before 9.0.0.M2 processes redirects before considering security constraints and Filters, which allows remote attackers to determine the existence of a directory via a URL that lacks a trailing / (slash) character.
#### CVE-2014-0075
Integer overflow in the parseChunkHeader function in java/org/apache/coyote/http11/filters/ChunkedInputFilter.java in Apache Tomcat before 6.0.40, 7.x before 7.0.53, and 8.x before 8.0.4 allows remote attackers to cause a denial of service (resource consumption) via a malformed chunk size in chunked transfer coding of a request during the streaming of data.
#### BDSA-2016-0256
When a user attempts login Realm implementations do not process the password input if the username is invalid. This allows remote attackers to obtain valid username details through a timing attack.

The default configuration includes LockOutRealm which makes exploitation of this vulnerability harder.
#### BDSA-2020-0328
Apache Tomcat is vulnerable to HTTP request smuggling.  If Apache is configured behind a reverse proxy that is incorrectly handling requests, a remote attacker can make requests to obtain internal files from the server.
#### BDSA-2020-3628
Apache Tomcat is vulnerable to information disclosure via **HTTP/2** request header mix-up. An attacker could exploit this by reusing a HTTP request header from a previous stream on an **HTTP/2** connection. This may cause leakage of information between requests.
#### CVE-2016-0706
Apache Tomcat 6.x before 6.0.45, 7.x before 7.0.68, 8.x before 8.0.31, and 9.x before 9.0.0.M2 does not place org.apache.catalina.manager.StatusManagerServlet on the org/apache/catalina/core/RestrictedServlets.properties list, which allows remote authenticated users to bypass intended SecurityManager restrictions and read arbitrary HTTP requests, and consequently discover session ID values, via a crafted web application.
#### CVE-2014-0119
Apache Tomcat before 6.0.40, 7.x before 7.0.54, and 8.x before 8.0.6 does not properly constrain the class loader that accesses the XML parser used with an XSLT stylesheet, which allows remote attackers to (1) read arbitrary files via a crafted web application that provides an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue, or (2) read files associated with different web applications on a single Tomcat instance via a crafted web application.
#### BDSA-2020-1664
Apache Tomcat is vulnerable to an infinite loop flaw in it's handling of websocket frames. A remote attacker may be able to repeatedly send specially crafted websocket frames to cause a denial-of-service (DoS).
#### CVE-2019-2684
Vulnerability in the Java SE, Java SE Embedded component of Oracle Java SE (subcomponent: RMI). Supported versions that are affected are Java SE: 7u211, 8u202, 11.0.2 and 12; Java SE Embedded: 8u201. Difficult to exploit vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise Java SE, Java SE Embedded. Successful attacks of this vulnerability can result in unauthorized creation, deletion or modification access to critical data or all Java SE, Java SE Embedded accessible data. Note: This vulnerability applies to Java deployments, typically in clients running sandboxed Java Web Start applications or sandboxed Java applets (in Java SE 8), that load and run untrusted code (e.g., code that comes from the internet) and rely on the Java sandbox for security. This vulnerability can also be exploited by using APIs in the specified Component, e.g., through a web service which supplies data to the APIs. CVSS 3.0 Base Score 5.9 (Integrity impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N).
#### BDSA-2016-0059
A HTTP response splitting vulnerability exists in Apache Tomcat due to a failure to sanitize attacker controlled inputs in HTTP requests.
#### BDSA-2016-0259
The error handling of the send file code for the `NIO` HTTP connector causes the current Processor object to be added to the processor cache multiple times. This allows the same Processor to be used for concurrent requests. 

Sharing a Processor can result in information leakage between requests including, but not limited to, session IDs and the response body.
#### BDSA-2016-0269
Tomcat's SecurityManager does not sufficiently handle permissions while reading system properties. The `getProperty()` method implemented in the `Digester.java` class does not sufficiently check for permissions before returning system property information.

Tomcat's system property replacement feature for configuration files could be used by an attacker to bypass the SecurityManager and read system properties that should not be visible.
#### CVE-2014-0099
Integer overflow in java/org/apache/tomcat/util/buf/Ascii.java in Apache Tomcat before 6.0.40, 7.x before 7.0.53, and 8.x before 8.0.4, when operated behind a reverse proxy, allows remote attackers to conduct HTTP request smuggling attacks via a crafted Content-Length HTTP header.
#### CVE-2013-4590
Apache Tomcat before 6.0.39, 7.x before 7.0.50, and 8.x before 8.0.0-RC10 allows attackers to obtain "Tomcat internals" information by leveraging the presence of an untrusted web application with a context.xml, web.xml, *.jspx, *.tagx, or *.tld XML document containing an external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue.
#### CVE-2015-5174
Directory traversal vulnerability in RequestUtil.java in Apache Tomcat 6.x before 6.0.45, 7.x before 7.0.65, and 8.x before 8.0.27 allows remote authenticated users to bypass intended SecurityManager restrictions and list a parent directory via a /.. (slash dot dot) in a pathname used by a web application in a getResource, getResourceAsStream, or getResourcePaths call, as demonstrated by the $CATALINA_BASE/webapps directory.
#### CVE-2013-4322
Apache Tomcat before 6.0.39, 7.x before 7.0.50, and 8.x before 8.0.0-RC10 processes chunked transfer coding without properly handling (1) a large total amount of chunked data or (2) whitespace characters in an HTTP header value within a trailer field, which allows remote attackers to cause a denial of service by streaming data.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-3544.
#### CVE-2014-7810
The Expression Language (EL) implementation in Apache Tomcat 6.x before 6.0.44, 7.x before 7.0.58, and 8.x before 8.0.16 does not properly consider the possibility of an accessible interface implemented by an inaccessible class, which allows attackers to bypass a SecurityManager protection mechanism via a web application that leverages use of incorrect privileges during EL evaluation.
#### BDSA-2016-0254
A malicious web application is able to bypass a configured SecurityManager by manipulating the configuration parameters `engineOptionsClass` and `scratchdir` for the JSP Servlet.
#### BDSA-2022-3105
Apache Tomcat does not fully respect the intent of the `rejectIllegalHeader` configuration option to drop all requests with illegal headers. A remote attacker could potentially smuggle requests with a specially crafted `Content-Length` header when Tomcat is also behind a reverse proxy that does the same. 

**Note:** This vulnerability only manifests when `rejectIllegalHeader` is set to `false`, which is **not** the default setting for any version higher than the **8.5.x** series.
#### BDSA-2017-1201
Apache Tomcat is vulnerable to information disclosure due to improper security constraints implementation for resources served by the `VirtualDirContext`.
#### BDSA-2018-2546
Tomcat is vulnerable to a security constraints bypass as it does not carry out host name verification in TLS secured communications.  A remote attacker can exploit this vulnerability to obtain sensitive information.
#### BDSA-2021-0069
Apache Tomcat is vulnerable to information disclosure due to unexpected function behavior. A remote attacker could bypass certain undisclosed security constraints, or view JSP source code,  by sending maliciously crafted requests to a vulnerable host. It should be noted that only instances of Tomcat that serve resources on machines utilizing NTFS are vulnerable, and these must be using certain configurations.
#### CVE-2014-0227
java/org/apache/coyote/http11/filters/ChunkedInputFilter.java in Apache Tomcat 6.x before 6.0.42, 7.x before 7.0.55, and 8.x before 8.0.9 does not properly handle attempts to continue reading data after an error has occurred, which allows remote attackers to conduct HTTP request smuggling attacks or cause a denial of service (resource consumption) by streaming data with malformed chunked transfer coding.