### PR TITLE
Synopsys Automated PR: Update com.fasterxml.jackson.core:jackson-databind:2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.0.4</version>
+            <version>2.14.2</version>
         </dependency>
 
         <!-- Spring MVC framework -->


### PR DESCRIPTION
### Vulnerabilities associated with this PR: 
#### BDSA-2017-2725
Deserialization of untrusted user data in Jackson Databind could allow an attacker to perform Remote Code Execution via specially crafted JSON input. 

This issue exists because of an incomplete fix for CVE-2017-7525 which the vendor tried to address through an incomplete blacklist.
#### BDSA-2019-2369
jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this Default Typing must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2019-3151
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest. The target service must also have the `ehcache` JAR file in the class path, and the attacker must also be able to find a RMI service endpoint to access.
#### BDSA-2020-0582
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by "gadgets" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2018-4043
Jackson Databind has a vulnerability in the way it handles some classes during deserialization. This is exploitable via a gadget that bypasses a blacklist and allows an attacker to perform remote code execution (RCE).
#### BDSA-2020-0486
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a "gadget" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2020-0689
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by "gadgets" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### CVE-2020-25649
A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.
#### BDSA-2021-0012
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with `DriverAdapterCPDS` gadgets. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2018-1946
Jackson Databind contains a deserialization flaw when configured with Oracle JDBC drivers. An unauthenticated attacker could create a specially-crafted payload that when deserialized in `Jackson-databind` which can lead to remote code execution (*RCE*).
#### BDSA-2018-4532
A server side request forgery (SSRF) vulnerability has been discovered in FasterXML Jackson-Databind. An attacker could exploit this vulnerability to execute malicious requests against the target system.
#### BDSA-2020-4026
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with the `com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource` gadget.

An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application using this gadget on the classpath with default typing enabled.
#### BDSA-2020-4813
Jackson Databind is vulnerable to remote code execution (RCE) due to the improper handling of polymorphic deserialization with gadgets in the `ignite-jta` class. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has the affected gadget on the classpath and default typing is enabled.
#### BDSA-2018-4047
Jackson Databind has a vulnerability in the way it handles some classes during deserialization. This is exploitable via a gadget that bypasses a blacklist and allows an attacker to perform remote code execution (RCE).
#### BDSA-2020-1416
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2019-3215
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with the `apache-log4j-extras` gadget. An attacker could exploit this vulnerability by providing a malicious Java Naming and Directory Interface (JNDI) service to a vulnerable application which has this gadget on the classpath and has default typing enabled.
#### BDSA-2020-0553
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.  The target service must also have the `javax.swing` JAR file in the class path, and the attacker must also be able to find a RMI service endpoint to access.
#### BDSA-2020-4024
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with gadgets in the `tomcat:naming-factory-dbcp` library. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has the affected gadget on the classpath and default typing enabled.
#### BDSA-2019-4214
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this Default Typing must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2019-2980
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a "gadget" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.
#### BDSA-2019-3135
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest. An attacker must also be able to find a RMI service endpoint to access.
#### BDSA-2020-3826
FasterXML Jackson Databind contains a Java deserialization vulnerability.  Under certain conditions, this allows a remote attacker to achieve remote code execution. Systems using Jackson Databind to deserialize untrusted data may be vulnerable.
#### BDSA-2021-0014
FasterXML Jackson-Databind contains a remote code execution (RCE) vulnerability because it does not block access to a gadget class. This could allow an attacker to exploit a potential mishandling of polymorphic deserialization by supplying a crafted input.
#### BDSA-2019-2355
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to insufficient blacklisting of  dangerous classes when used along with Ehcache. Ehcache is an open source, standards-based cache that boosts performance. An attacker could leverage a dangerous transaction manager class to deserialize untrusted input and execute arbitrary code on the underlying host.
#### BDSA-2019-4111
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with `net.sf.ehcache` gadgets. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2020-2193
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2020-4021
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with the `com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource` gadget.

An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application using this gadget on the classpath with default typing enabled.
#### BDSA-2018-0357
Jackson Databind is vulnerable to remote code execution (*RCE*) due to a deserialization flaw. An unauthenticated attacker could craft a malicious `JSON` input for the `readValue()` method of the `ObjectMapper`. Upon sending it to the component, a denial of service (*DoS*) will occur and the injected code will be executed.
#### BDSA-2020-0252
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to an exposed JSON end path.
#### BDSA-2020-1417
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2017-1861
An unauthenticated attacker can create a specially crafted payload that when deserialized in `Jackson-Databind` can lead to Code Execution.
#### BDSA-2021-0015
FasterXML Jackson-Databind contains a remote code execution (RCE) vulnerability because it does not block access to a gadget class. This could allow an attacker to exploit a potential mishandling of polymorphic deserialization by supplying a crafted input.
#### BDSA-2021-0016
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with `DriverAdapterCPDS` gadgets. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2020-0584
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a "gadget" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2019-1881
An improper privilege management vulnerability has been discovered in FasterXML jackson-databind. An attacker could exploit this vulnerability through an external JSON endpoint to target a specific class from executing malicious polymorphic deserialization which could lead to arbitrary code execution against the system.
#### BDSA-2020-1415
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2020-0690
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by "gadgets" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2020-2643
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by "gadgets" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2020-0487
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a "gadget" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2019-3136
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.  The target service must also have the `commons-dbcp` JAR file in the class path, and the attacker must also be able to find a RMI service endpoint to access.
#### BDSA-2018-4597
FasterXML jackson-databind is vulnerable to remote code execution (RCE) via the process of polymorphic deserialization when malformed data is supplied.
#### BDSA-2020-0361
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.  The target service must also have the `ibatis-sqlmap` JAR file in the class path, and the attacker must also be able to find a RMI service endpoint to access.
#### BDSA-2018-0788
FasterXML jackson-databind contains a remote code execution (*RCE*) vulnerability due to an incomplete fix for the **CVE-2017-7525** deserialization flaw. An unauthenticated attacker can exploit this vulnerability via `readValue` method to execute arbitrary code.
#### BDSA-2018-4535
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to failure to block the slf4j-ext class from polymorphic deserialization . A remote attacker could exploit this vulnerability to execute arbitrary commands on the underlying system.
#### BDSA-2021-0013
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with a `Xalan` gadget derivative. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2020-1428
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2018-4046
Jackson Databind has a vulnerability in the way it handles some classes during deserialization. This is exploitable via a gadget that bypasses a blacklist and allows an attacker to perform remote code execution (RCE).
#### BDSA-2019-2978
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a "gadget" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.
#### BDSA-2019-4213
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this Default Typing must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.
#### BDSA-2019-4338
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application. It should be noted that this 'Default Typing' must be enabled for an externally exposed JSON end-path in order for this vulnerability to manifest.  The target service must also have the `bus-proxy` JAR file in the class path, and the attacker must also be able to find a RMI service endpoint to access.
#### BDSA-2017-0836
Jackson-databind is vulnerable to remote code execution (RCE) when deserializing via the `readValue()` method of `ObjectMapper`.
#### BDSA-2018-4608
FasterXML Jackson-Databind is vulnerable to referencing XML external entities (XXE) via the process of polymorphic deserialization when malformed data is supplied. This vulnerability can be exploited to read memory outside the scope of the application or consume excessive amount of computing resources to cause denial-of-service (DoS) condition.
#### BDSA-2020-3902
When Default Typing is enabled,  jackson-databind is vulnerable to remote code execution (RCE) through the provision of a maliciously crafted JSON file that exploits how polymorphic data types are handled.
#### BDSA-2020-4023
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with gadgets in the `tomcat:naming-factory-dbcp` library. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has the affected gadget on the classpath and default typing enabled.
#### CVE-2020-36518
jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.
#### BDSA-2020-4020
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with `PerUserPoolDataSource` gadgets. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2020-0354
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application.
#### BDSA-2020-0583
Jackson Databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a "gadget" used by the application. A remote attacker could execute arbitrary commands on the underlying system. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2020-4022
Jackson-Databind is vulnerable to remote code execution (RCE) due to improper handling of polymorphic deserialization with `SharedPoolDataSource` gadgets. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2020-4090
Jackson Databind FasterXML contains a deserialization vulnerability. Under certain conditions, this allows a remote attacker to achieve remote code execution.  Systems using Jackson Databind to deserialize untrusted data may be vulnerable. Default typing must be enabled in order for this vulnerability to manifest.

Version **2.10.0** of Databind introduced functionality which allows developers to limit subtypes allowed by default typing using a whitelist.
#### BDSA-2020-0363
FasterXML jackson-databind is vulnerable to remote code execution (RCE) due to how polymorphic data types are handled by a gadget used by the application. A remote attacker could execute arbitrary commands on the underlying system by submitting crafted JSON messages to the application.
#### BDSA-2020-3827
FasterXML Jackson Databind contains a Java deserialization vulnerability.  Under certain conditions, this allows a remote attacker to achieve remote code execution.  Systems using Jackson Databind to deserialize untrusted data may be vulnerable.
#### BDSA-2019-1550
An improper privilege management vulnerability has been discovered in Jackson Databind. An attacker could exploit this vulnerability through an external JSON endpoint with exposed MySQL drivers to send crafted JSON objects. The malicious JSON object will be deserialized by the application which can be manipulated to read arbitrary files on the system.
#### BDSA-2018-1847
FasterXML jackson-databind is vulnerable to a potential remote-code-execution(*RCE*) via serialization gadgets in the `Jodd-db` library. If configuration conditions are valid an attacker could exploit this vulnerability to execute arbitrary code on a target system.
#### BDSA-2018-4847
jackson-databind is vulnerable to the exfiltration of sensitive data due to the use of a dangerous code construct. An attacker could retrieve data over an FTP connection by providing the application with crafted serialized input.
#### BDSA-2022-2768
Jackson Databind is vulnerable to denial-of-service (DoS) due to the improper management of system resources within its `BeanDeserializer` component. A remote attacker could cause a vulnerable server to crash by causing that server to process a maliciously crafted serialized object.
#### BDSA-2019-1837
Jackson-Databind is vulnerable to arbitrary file reads due to improper handling of polymorphic deserialization with the `jdom` and `jdom2` gadgets. An attacker could exploit this vulnerability by sending a maliciously crafted JSON message to a vulnerable application which has one of these gadgets on the classpath and default typing enabled.
#### BDSA-2022-2765
Jackson Databind is vulnerable to denial-of-service (DoS) due to the improper management of system resources within its primitive value deserialization functionality. A remote attacker could leverage this issue in order to cause a vulnerable system to crash.
#### BDSA-2019-4644
It was discovered that jackson-mapper-asl  is vulnerable to XML External Entity (XXE) attacks due to the unsafe implementation of parsing functionality. An attacker could exploit this vulnerability via a crafted request to execute an XML external entities (XXE) attack against the application.